### PR TITLE
Fix - DEF-1175 - private-undistributed.yml updated with a new combination

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -5,6 +5,7 @@ allow-licenses:
   - 'AFL-3.0'
   - 'Apache-2.0'
   - 'Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1'
+  - 'Apache-2.0 AND BSD-3-Clause AND MPL-2.0'
   - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0'
   - 'APL-1.0'
   - 'Artistic-2.0'


### PR DESCRIPTION
## Context
https://coveord.atlassian.net/browse/DEF-1175

If some licenses are allowed individually, they also allowed together as well.

## Solution

`'Apache-2.0 AND BSD-3-Clause AND MPL-2.0'` added to `private-undistributed.yml`.

## Note

I added it only to `private-undistributed.yml` because `MPL-2.0` is not in the other groups.