### PR TITLE
+ 'MIT AND Python-2.0'

### DIFF
--- a/private-distributed.yml
+++ b/private-distributed.yml
@@ -25,6 +25,7 @@ allow-licenses:
   - 'ISC'
   - 'JSON'
   - 'MIT'
+  - 'MIT AND Python-2.0'
   - 'MIT-0'
   - 'MIT-advertising'
   - 'mpi-permissive'

--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -49,6 +49,7 @@ allow-licenses:
   - 'LGPL-3.0-only'
   - 'LGPL-3.0-or-later'
   - 'MIT'
+  - 'MIT AND Python-2.0'
   - 'MIT-0'
   - 'MIT-advertising'
   - 'mpi-permissive'

--- a/public.yml
+++ b/public.yml
@@ -26,6 +26,7 @@ allow-licenses:
   - 'JSON'
   - 'MIT'
   - 'MIT-0'
+  - 'MIT AND Python-2.0'
   - 'MIT-advertising'
   - 'mpi-permissive'
   - 'NCSA'


### PR DESCRIPTION
see https://github.com/coveo/indexingpipeline/actions/runs/4959148069/jobs/8872875942?pr=452

` The following dependencies have incompatible licenses:
  PythonTests/poetry.lock » exceptiongroup@1.1.1 – License: MIT AND Python-2.0
  Error: Dependency review detected incompatible licenses.`

