### PR TITLE
new combination of allowed licenses

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -39,6 +39,7 @@ allow-licenses:
   - 'GPL-3.0-only'
   - 'GPL-3.0-or-later'
   - 'GPL-3.0-or-later AND LGPL-2.1-only'
+  - 'GPL-3.0-only AND GPL-3.0-or-later AND LGPL-3.0-only'
   - 'HPND'
   - 'IBM-pibs'
   - 'ImageMagick'


### PR DESCRIPTION
Ran into this here:
https://github.com/coveo/org-search-monitoring-service/pull/206

Individually they are already all in the allow list.