### PR TITLE
Allow BSD-3-Clause AND BSD-3-Clause-Clear

### DIFF
--- a/private-distributed.yml
+++ b/private-distributed.yml
@@ -13,6 +13,7 @@ allow-licenses:
   - 'BSD-3-Clause'
   - 'BSD-3-Clause-Attribution'
   - 'BSD-3-Clause-Clear'
+  - 'BSD-3-Clause AND BSD-3-Clause-Clear'
   - 'BSL-1.0'
   - 'CC-BY-3.0'
   - 'CC-BY-4.0'


### PR DESCRIPTION
This is currently preventing us from updating the Webpack and TypeScript dependencies in the trainingplatform (aka Level Up) project.