### PR TITLE
+ Apache-2.0 & MIT into public

### DIFF
--- a/public.yml
+++ b/public.yml
@@ -2,6 +2,7 @@
 allow-licenses:
   - '0BSD'
   - 'Apache-2.0'
+  - 'Apache-2.0 AND MIT'
   - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0'
   - 'Beerware'
   - 'BlueOak-1.0.0'


### PR DESCRIPTION
Apache-2.0 and MIT are individually allowed, and here: https://github.com/coveo/cli/pull/1315, I have a pkg that uses an Apache-2.0&MIT license.