### PR TITLE
chore: add missing combined license

### DIFF
--- a/private-distributed.yml
+++ b/private-distributed.yml
@@ -26,6 +26,7 @@ allow-licenses:
   - 'ISC'
   - 'JSON'
   - 'MIT'
+  - 'MIT AND ISC'
   - 'MIT AND Python-2.0'
   - 'MIT-0'
   - 'MIT-advertising'

--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -55,6 +55,7 @@ allow-licenses:
   - 'LGPL-3.0-only'
   - 'LGPL-3.0-or-later'
   - 'MIT'
+  - 'MIT AND ISC'
   - 'MIT AND Python-2.0'
   - 'MIT AND MIT-0'
   - 'MIT-0'

--- a/public.yml
+++ b/public.yml
@@ -27,6 +27,7 @@ allow-licenses:
   - 'JSON'
   - 'MIT'
   - 'MIT-0'
+  - 'MIT AND ISC'
   - 'MIT AND Python-2.0'
   - 'MIT-advertising'
   - 'mpi-permissive'


### PR DESCRIPTION
Both `MIT` and `ISC` are allowed in every type of package, so the combination of both should be allowed too