### PR TITLE
CSEC-12808 Add ruby to allowed license

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -75,6 +75,7 @@ allow-licenses:
   - 'PSF-2.0'
   - 'Python-2.0'
   - 'Python-2.0.1'
+  - 'Ruby'
   - 'SAX-PD'
   - 'SPL-1.0'
   - 'Unlicense'


### PR DESCRIPTION
Adding the Ruby license to the undistributed group.

The ruby [license](https://www.ruby-lang.org/en/about/license.txt) is considered open source by most due to its dual licensing scheme.
It also allows modification for software used within the corporation (clause 2.b)
```
2. You may modify your copy of the software in any way, provided that
     you do at least ONE of the following:

       a) place your modifications in the Public Domain or otherwise
          make them Freely Available, such as by posting said
	  modifications to Usenet or an equivalent medium, or by allowing
	  the author to include your modifications in the software.

       b) use the modified software only within your corporation or
          organization.

       c) give non-standard binaries non-standard names, with
          instructions on where to get the original software distribution.

       d) make other distribution arrangements with the author.
```
It allowed distribution under specific requirements, but not being certain they were followed by our distributed code, I didn't include it.

Wikibedia article link for more info : https://en.wikipedia.org/wiki/Ruby_License