### PR TITLE
Add CAL-1.0 license

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -26,6 +26,7 @@ allow-licenses:
   - 'BSD-3-Clause-Clear'
   - 'BSD-3-Clause AND BSD-3-Clause-Clear'
   - 'BSL-1.0'
+  - 'CAL-1.0'
   - 'CC-BY-3.0'
   - 'CC-BY-4.0'
   - 'CC0-1.0'


### PR DESCRIPTION
# Context

In ML python project like [Case Classification](https://github.com/coveo/ml-nlp-dfp), we use torchserve and it requires a dependency called pillow that introduced this license when we were trying to update our dependencies https://github.com/coveo/ml-nlp-dfp/pull/940#issuecomment-1769152631
 
# Solution
Added the exception to private-undistributed.yml