### PR TITLE
Adding messy artistic + GPL license

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -10,6 +10,7 @@ allow-licenses:
   - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0'
   - 'Apache-2.0 AND CNRI-Python'
   - 'APL-1.0'
+  - 'Artistic-1.0-Perl AND GPL-1.0-or-later AND GPL-1.0-or-later OR (GPL-2.0-or-later OR Artistic-1.0)'
   - 'Artistic-2.0'
   - 'Beerware'
   - 'BlueOak-1.0.0'

--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -1,5 +1,6 @@
 # Allow list for closed-source undistributed projects.
 allow-licenses:
+  - '(Artistic-1.0 AND Artistic-2.0) OR (Artistic-1.0-Perl AND Artistic-2.0 AND GPL-1.0-or-later) OR (Artistic-2.0 AND GPL-2.0-or-later)'
   - '0BSD'
   - '0BSD AND BSD-2-Clause'
   - 'AFL-2.1'
@@ -10,7 +11,6 @@ allow-licenses:
   - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0'
   - 'Apache-2.0 AND CNRI-Python'
   - 'APL-1.0'
-  - 'Artistic-1.0-Perl AND GPL-1.0-or-later AND GPL-1.0-or-later OR (GPL-2.0-or-later OR Artistic-1.0)'
   - 'Artistic-2.0'
   - 'Beerware'
   - 'BlueOak-1.0.0'


### PR DESCRIPTION
[ML-2195](https://coveord.atlassian.net/browse/ML-2195)

License for text-unidecode is messy and triggering false positives. Adding it to the list of approved license definitions.


[ML-2195]: https://coveord.atlassian.net/browse/ML-2195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ