### PR TITLE
Add BSD-4-Clause license to allowed licenses for private undistributed

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -28,6 +28,7 @@ allow-licenses:
   - 'BSD-3-Clause-Attribution'
   - 'BSD-3-Clause-Clear'
   - 'BSD-3-Clause AND BSD-3-Clause-Clear'
+  - 'BSD-4-Clause'
   - 'BSL-1.0'
   - 'CC-BY-3.0'
   - 'CC-BY-4.0'


### PR DESCRIPTION
Hi there, I recently got blocked from adding this [dependency](https://github.com/snok/asgi-correlation-id/blob/main/LICENSE) due to incompatible license. I'm opening this PR on the off chance that nobody has tried to use this license before, however if it is already rejected pls let me know :) (is there a place I can look to see which licenses have already been accessed and denied?)

Not a lawyer, but theres a few clauses who's risk seems project dependent. (3 and 4). Is there a way to allow licenses on a per-project basis? 

Thanks!