### PR TITLE
add BSD-2-Clause AND BSD-4-Clause

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -24,6 +24,7 @@ allow-licenses:
   - 'BSD-2-Clause AND BSD-3-Clause'
   - 'BSD-2-Clause AND MIT'
   - 'BSD-2-Clause AND ISC'
+  - 'BSD-2-Clause AND BSD-4-Clause'
   - 'BSD-3-Clause'
   - 'BSD-3-Clause-Attribution'
   - 'BSD-3-Clause-Clear'


### PR DESCRIPTION
License check is failing here: https://github.com/coveo/ml-learning-to-retrieve/pull/16 
Since we have both these licenses allowed already I presume that their conjunction is also allowed?