### PR TITLE
[COMAI-1530] Allow another Apache 2.0 license

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -12,6 +12,7 @@ allow-licenses:
   - 'Apache-2.0 AND CNRI-Python'
   - 'Apache-2.0 AND LGPL-3.0-or-later'
   - 'Apache-2.0 AND LGPL-3.0-or-later AND MIT'
+  - 'Apache-2.0 WITH LLVM-exception'
   - 'APL-1.0'
   - 'Artistic-2.0'
   - 'Beerware'


### PR DESCRIPTION
`Apache-2.0 WITH LLVM-exception` is tripping up our dependency checker.

The dependency path seems to be `lit` <- `triton` <- `torch` <- `deli-serving`, so it's probably something that'll have to get added to the allowlist for the benefit of all deli projects.