### PR TITLE
add combination license

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -68,6 +68,8 @@ allow-licenses:
   - 'MIT AND ISC'
   - 'MIT AND Python-2.0'
   - 'MIT AND MIT-0'
+  - 'MIT AND MPL-2.0'
+  - 'MIT AND NOASSERTION AND Python-2.0'
   - 'MIT AND PSF-2.0'
   - 'MIT-0'
   - 'MIT-advertising'

--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -69,7 +69,6 @@ allow-licenses:
   - 'MIT AND Python-2.0'
   - 'MIT AND MIT-0'
   - 'MIT AND MPL-2.0'
-  - 'MIT AND NOASSERTION AND Python-2.0'
   - 'MIT AND PSF-2.0'
   - 'MIT-0'
   - 'MIT-advertising'


### PR DESCRIPTION
Two combination licenses are blocking release of a vulnerability patch [here](https://github.com/coveo-platform/ml-product-profitability/pull/277). These licenses are individually approved.