### PR TITLE
[QA-1479] add openvpn-openssl-exception

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -65,6 +65,7 @@ allow-licenses:
   - 'LGPL-3.0'
   - 'LGPL-3.0-only'
   - 'LGPL-3.0-or-later'
+  - 'LGPL-3.0-or-later WITH openvpn-openssl-exception'
   - 'MIT'
   - 'MIT AND ISC'
   - 'MIT AND Python-2.0'


### PR DESCRIPTION
This license restriction came up when were were migrating from a Jenkins job to a Github action for the audit dashboard:
https://github.com/coveo-platform/audit-dashboard/pull/51

`LGPL-3.0-or-later` is already on the list, and if I understand correctly, `openvpn-openssl-exception` loosens the restrictions.

It's coming up on `psycopg2` for postgres