### PR TITLE
FINOPS-1171: Fix Dependency Warnings for ADTK PR

### DIFF
--- a/public.yml
+++ b/public.yml
@@ -15,6 +15,7 @@ allow-licenses:
   - 'BSD-3-Clause-Attribution'
   - 'BSD-3-Clause-Clear'
   - 'BSL-1.0'
+  - 'CAL-1.0'
   - 'CC-BY-3.0'
   - 'CC-BY-4.0'
   - 'CC0-1.0'


### PR DESCRIPTION
#[FINOPS-1171: Fix Dependency Warnings for ADTK PR](https://coveord.atlassian.net/browse/FINOPS-1171) :rocket:

The dependency review of the [FinOps PR](https://github.com/coveo-platform/cloud-costs/pull/276) returned a warning for the matplotlib & pillow packages, both are used in many other repos.

In the case of pillow, it has been previously identified as a [false positive](https://coveo.slack.com/archives/CFNCWR214/p1713378324636679). I suspect the same for the matplotlib package.

Also of notice, I received a warning for CAL-1.0 & HPND for matplotlib, even though HPND is part of the allowed licenses.

Here's the [initial post](https://coveo.slack.com/archives/CFNCWR214/p1720185297578439) in Slack.