### PR TITLE
[COMAI-2730] Review license for "BSD-1-Clause AND BSD-2-Clause" (appnope)

### DIFF
--- a/public.yml
+++ b/public.yml
@@ -8,6 +8,7 @@ allow-licenses:
   - 'BlueOak-1.0.0'
   - 'BSD-1-Clause'
   - 'BSD-2-Clause'
+  - 'BSD-1-Clause AND BSD-2-Clause'
   - 'BSD-2-Clause-Patent'
   - 'BSD-2-Clause-Views'
   - 'BSD-2-Clause AND MIT'


### PR DESCRIPTION
The PR [coveo-platform/ml-reranker#20](https://github.com/coveo-platform/ml-reranker/pull/20) raises [a license infraction:](https://github.com/coveo-platform/ml-reranker/actions/runs/10475279908/job/29011570344?pr=20)

> The validity of the licenses of the dependencies below could not be determined. Ensure that they are valid SPDX licenses:
  poetry.lock » appnope@0.1.4 – License: BSD-1-Clause AND BSD-2-Clause AND NOASSERTION
  Error: Dependency review could not detect the validity of all licenses.
  
>  We could not detect a license for the following dependencies:
  poetry.lock » pywin32@306
  
  This dependency was introduced by ipykernel, which is a **dev-time** dependency:
```
$ poetry show appnope
 name         : appnope
 version      : 0.1.4
 description  : Disable App Nap on macOS >= 10.9

required by
 - ipykernel *
 ```
- Is this a **private-undistributed** dependency
  - Yes. It is a dev-time dependency for a production backend service. The project is [ml-reranker](https://github.com/coveo-platform/ml-reranker), which is non-public and non-distributed
- Are the constituent licenses permitted?
  - Yes: [BSD-2-Clause](https://github.com/coveo/dependency-allowed-licenses/blob/1ded3e131e0547484f2a6876bcff20e0960b16f5/private-undistributed.yml#L23) AND [BSD-3-Clause](https://github.com/coveo/dependency-allowed-licenses/blob/1ded3e131e0547484f2a6876bcff20e0960b16f5/private-undistributed.yml#L32)
- What about each of the sub-dependencies?
  - There are none 