### PR TITLE
Add new valid combination for ruff 0.7.3

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -83,6 +83,7 @@ allow-licenses:
   - 'MPL-2.0'
   - 'NCSA'
   - 'Nokia'
+  - '0BSD AND Apache-2.0 AND BSD-3-Clause AND MIT'
   - 'ODC-By-1.0'
   - 'OFL-1.1'
   - 'PDDL-1.0'


### PR DESCRIPTION
This adds a combination of already supported licenses:

 0BSD  
 Apache-2.0 
 BSD-3-Clause  
 MIT