### PR TITLE
Update private-undistributed.yml

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -26,6 +26,7 @@ allow-licenses:
   - 'BSD-2-Clause AND BSD-2-Clause-Views'
   - 'BSD-2-Clause AND BSD-3-Clause'
   - 'BSD-2-Clause AND BSD-3-Clause AND LGPL-3.0-only'
+  - 'BSD-2-Clause AND BSD-3-Clause AND LGPL-2.0-or-later AND MIT'
   - 'BSD-2-Clause AND MIT'
   - 'BSD-2-Clause AND ISC'
   - 'BSD-2-Clause AND BSD-4-Clause'


### PR DESCRIPTION
For https://github.com/coveo-platform/ml-genqa/pull/490.

This pull request includes a small change to the `private-undistributed.yml` file. The change adds a new entry to the `allow-licenses` list.

* [`private-undistributed.yml`](diffhunk://#diff-4abe1e5ee4e22008cda67610b5b6d37175ed6190300af653a93e1cba751f082fR29): Added 'BSD-2-Clause AND BSD-3-Clause AND LGPL-2.0-or-later AND MIT' to the `allow-licenses` list.