### PR TITLE
Add new combination of allowed licenses

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -14,6 +14,7 @@ allow-licenses:
   - 'Apache-2.0 AND EPL-1.0 AND EPL-2.0'
   - 'Apache-2.0 AND LGPL-3.0-or-later'
   - 'Apache-2.0 AND LGPL-3.0-or-later AND MIT'
+  - 'Apache-2.0 AND MIT AND MPL-2.0'
   - 'Apache-2.0 WITH LLVM-exception'
   - 'APL-1.0'
   - 'Artistic-2.0'


### PR DESCRIPTION
For botocore 1.35.59 we need `Apache-2.0 AND MIT AND MPL-2.0`, each already allowed individually.