### PR TITLE
add 0BSD AND ISC AND MIT to private-distributed.yml

### DIFF
--- a/private-distributed.yml
+++ b/private-distributed.yml
@@ -1,6 +1,7 @@
 # Allow list for closed-source distributed projects.
 allow-licenses:
   - '0BSD'
+  - '0BSD AND ISC AND MIT'
   - 'Apache-2.0'
   - 'Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT'
   - 'Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT'


### PR DESCRIPTION
J:[DEF-160](https://coveord.atlassian.net/browse/DEF-160)

We have a failing renovate PR because of this missing license combination. All three are already in the list individually so I figured the aggregation of the three should be alright.

https://github.com/coveo-platform/admin-ui/actions/runs/12229437331
https://github.com/coveo/plasma/actions/runs/12236725805?pr=3978

[DEF-160]: https://coveord.atlassian.net/browse/DEF-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ