### PR TITLE
Add yet another combination

### DIFF
--- a/public.yml
+++ b/public.yml
@@ -4,6 +4,7 @@ allow-licenses:
   - '0BSD AND ISC AND MIT'
   - 'Apache-2.0'
   - 'Apache-2.0 AND MIT'
+  - 'Apache-2.0 AND MIT AND MIT-0'
   - 'Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT'
   - 'Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT'
   - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0'


### PR DESCRIPTION
We got a `Apache-2.0 AND MIT AND MIT-0` license, which is a combination of license we usually accept.

See this project: https://github.com/coveo-platform/ml-build-agent-sagemaker/pull/50