### PR TITLE
Update private-undistributed.yml

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -33,6 +33,7 @@ allow-licenses:
   - 'BSD-2-Clause AND BSD-3-Clause AND LGPL-2.0-or-later AND MIT'
   - 'BSD-2-Clause AND MIT'
   - 'BSD-2-Clause AND ISC'
+  - 'BSD-2-Clause AND ISC AND Python-2.0'
   - 'BSD-3-Clause AND ISC AND MIT'
   - 'BSD-2-Clause AND BSD-4-Clause'
   - 'BSD-3-Clause'


### PR DESCRIPTION
This pull request includes a small change to the `private-undistributed.yml` file. The change adds a new combination of licenses to the `allow-licenses` list.

* [`private-undistributed.yml`](diffhunk://#diff-4abe1e5ee4e22008cda67610b5b6d37175ed6190300af653a93e1cba751f082fR36): Added 'BSD-2-Clause AND ISC AND Python-2.0' to the `allow-licenses` list.

J:DEF-160