### PR TITLE
Add missing licenses combinations for admin-ui and plasma

### DIFF
--- a/private-distributed.yml
+++ b/private-distributed.yml
@@ -49,6 +49,7 @@ allow-licenses:
   - 'Python-2.0.1'
   - 'SAX-PD'
   - 'Unlicense'
+  - 'LicenseRef-scancode-public-domain AND Unlicense'
   - 'UPL-1.0'
   - 'W3C'
   - 'Wsuipa'

--- a/public.yml
+++ b/public.yml
@@ -8,6 +8,7 @@ allow-licenses:
   - 'Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT'
   - 'Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT'
   - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0'
+  - '(Apache-2.0 AND GPL-2.0-only AND MPL-2.0 AND MS-PL) OR (Apache-2.0 AND GPL-2.0-only AND MPL-2.0)'
   - 'Beerware'
   - 'BlueOak-1.0.0'
   - 'BSD-1-Clause'


### PR DESCRIPTION
Unblocking those dependencies update:

https://github.com/coveo/plasma/actions/runs/12790516240
https://github.com/coveo-platform/admin-ui/actions/runs/12881547672

Unsure about the `LicenseRef-scancode-public-domain` btw, let me know if its not approved.