### PR TITLE
[ML-3321] Add MIT AND ZPL-2.1 license to the list of private undistributed licenses

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -90,6 +90,7 @@ allow-licenses:
   - 'MIT AND MPL-2.0'
   - 'MIT AND PSF-2.0'
   - 'MIT AND Python-2.0.1'
+  - 'MIT AND ZPL-2.1'
   - 'MIT-0'
   - 'MIT-advertising'
   - 'mpi-permissive'


### PR DESCRIPTION
### Context
pytz package has updated their license. Their license is not listed in the list of allowed licenses.

### Solution
Add MIT AND ZPL-2.1 license to the list of allowed licenses.