### PR TITLE
Add license for aiohappyeyeballs

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -104,6 +104,7 @@ allow-licenses:
   - 'Nokia'
   - '0BSD AND Apache-2.0 AND BSD-3-Clause AND MIT'
   - '0BSD AND BSD-2-Clause AND BSD-3-Clause'
+  - '0BSD AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference AND PSF-2.0 AND Python-2.0'
   - 'ODC-By-1.0'
   - 'OFL-1.1'
   - 'PDDL-1.0'


### PR DESCRIPTION
aiohappyeyeballs is a depenency of aiohttp which is a generic python package.

```
 The following dependencies have incompatible licenses:
  poetry.lock » aiohappyeyeballs@2.4.6 – License: 0BSD AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference AND PSF-2.0 AND Python-2.0
  Error: Dependency review detected incompatible licenses.
```

Dependency graph from our internal deli package:

```
deli-serving 6.8.0 Provides common functionality for the model serving step.
├── aiohttp ==3.*
│   ├── aiohappyeyeballs >=2.3.0 
```
