### PR TITLE
Add LicenseRef-scancode-other-permissive to fix django license

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -49,6 +49,7 @@ allow-licenses:
   - 'BSD-3-Clause AND BSD-3-Clause-Clear'
   - 'BSD-2-Clause AND BSD-3-Clause AND Python-2.0'
   - 'BSD-3-Clause AND LicenseRef-scancode-protobuf'
+  - 'BSD-3-Clause AND LicenseRef-scancode-other-permissive AND Python-2.0'
   - 'BSD-4-Clause'
   - 'BSL-1.0'
   - 'CAL-1.0 AND PSF-2.0'


### PR DESCRIPTION
Hello, I have the following license issue in a renovate PR to bump a [minor version](https://docs.djangoproject.com/en/5.1/releases/4.2.19/) of [django](https://github.com/django/django):

https://github.com/coveo-platform/audit-dashboard/pull/116 -> https://github.com/coveo-platform/audit-dashboard/actions/runs/13378382297

> django | 4.2.19 | (Apache-2.0 AND BSD-3-Clause AND LicenseRef-scancode-other-permissive AND Python-2.0 AND Python-2.0.1) OR (BSD-3-Clause AND LicenseRef-scancode-other-permissive AND Python-2.0 AND Python-2.0.1) | Incompatible License

From what I understand, the issue is that `LicenseRef-scancode-other-permissive ` is not authorized, but what I don't understand is why it was not an issue before with the last 2 minor bumps:
- https://github.com/coveo-platform/audit-dashboard/pull/103 -> https://github.com/coveo-platform/audit-dashboard/actions/runs/12777789257
- https://github.com/coveo-platform/audit-dashboard/pull/91 -> https://github.com/coveo-platform/audit-dashboard/actions/runs/12204839114

Here are the 2 licenses I found for for django:
- https://github.com/django/django/blob/main/LICENSE (no recent change)
- https://github.com/django/django/blob/main/LICENSE.python

The last one was updated recently but just to remove a year, see https://github.com/django/django/commit/53df2ee7a42cf965126839b59308e49b58007669, not sure if it's that change that causes the tool to detect `LicenseRef-scancode-other-permissive` now.

I saw this [recent PR](https://github.com/coveo/dependency-allowed-licenses/pull/81) too with almost the same issue, but it was for `LicenseRef-scancode-unknown-license-reference` so not sure if the solution will be the same 🤔 

So I'm opening this PR to see with you if it's a legit license permission issue, and if yes, is it OK to add it like that to the `private-undistributed.yml`?

Thanks!

Edit: it's for our internal QA audit dashboard and nothing urgent 👍 