### PR TITLE
Add Apache-2.0 AND LicenseRef-scancode-unknown-license-reference

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -285,6 +285,7 @@ allow-licenses:
   - 'Apache-2.0 AND EPL-1.0 AND EPL-2.0'
   - 'Apache-2.0 AND LGPL-3.0-or-later'
   - 'Apache-2.0 AND LGPL-3.0-or-later AND MIT'
+  - 'Apache-2.0 AND LicenseRef-scancode-unknown-license-reference'
   - 'Apache-2.0 AND MIT AND MIT-0'
   - 'Apache-2.0 AND MIT AND MPL-2.0'
   - 'Apache-2.0 WITH LLVM-exception'


### PR DESCRIPTION
Fixes transitive dependency only half detected.

`Apache-2.0 AND LicenseRef-scancode-unknown-license-reference`

Apache-2.0 is already enough.