### PR TITLE
Remove Cal-1.0 license from private-undistributed

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -316,7 +316,6 @@ allow-licenses:
   - 'BSD-3-Clause AND LicenseRef-scancode-protobuf'
   - 'BSD-4-Clause'
   - 'BSL-1.0'
-  - 'CAL-1.0 AND PSF-2.0'
   - 'CC-BY-3.0'
   - 'CC-BY-4.0'
   - 'CC-BY-4.0 AND CC-BY-SA-4.0 AND GPL-2.0-only AND GPL-2.0-or-later'


### PR DESCRIPTION
Resolves Issue #88 :

> We cannot approve [Cal-1.0] for private undistributed. Is there a possibility to also remove it from line 319? Do you need to create another PR?