### PR TITLE
fix: Allow org.json/json since it's public domain

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -1,8 +1,11 @@
 # Allow list of specific dependencies that have stable licenses and can be ignored.
 # This is to circumvent GitHub having a flaky license discovery for some libraries.
 # A script is present in the scripts folder to generate the purl for a specific groupId.
+# Keep this list sorted alphabetically please!
 allow-dependencies-licenses:
-  # All Spring Framework, Spring Boot, Spring Cloud and Spring Data. Keep this list ordered.
+  # org.json/json has a public domain license but it is not detected properly by GitHub (https://github.com/stleary/JSON-java/blob/master/LICENSE)
+  - 'pkg:maven/org.json/json'
+  # All Spring Framework, Spring Boot, Spring Cloud and Spring Data.
   - 'pkg:maven/org.springframework/beandoc'
   - 'pkg:maven/org.springframework/framework-api'
   - 'pkg:maven/org.springframework/framework-docs'


### PR DESCRIPTION
Per https://github.com/stleary/JSON-java/blob/master/LICENSE, this library is in the public domain. However, it is not a valid SPDX license so it's getting flagged as `NONE` by clearly defined (ref. https://github.com/clearlydefined/curated-data/pull/26813).

This will resolve this issue by allowing the library specifically.