### PR TITLE
Add MPL-2.0 licence for private-distributed

### DIFF
--- a/private-distributed.yml
+++ b/private-distributed.yml
@@ -57,3 +57,4 @@ allow-licenses:
   - 'Xerox'
   - 'Zlib'
   - 'ZPL-2.1'
+  - 'MPL-2.0'


### PR DESCRIPTION
Adding licence for MPL-2.0 to resolve the issue with the hashicorp/setup-terraform issue 

https://github.com/coveo/doc_jekyll-public-site/actions/runs/14645537137


<img width="840" alt="Screenshot 2025-04-24 at 3 19 44 PM" src="https://github.com/user-attachments/assets/05beb1cf-a4e6-4aee-9008-096a7072ee24" />
