### PR TITLE
feat: new Allowed license for private undistributed

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -420,6 +420,7 @@ allow-licenses:
   - 'EPL-1.0'
   - 'EPL-2.0'
   - 'EPL-2.0 AND Apache-2.0 AND BSD-3-Clause'
+  - 'EPL-2.0 AND BSD-3-Clause AND Apache-1.1 AND EPL-2.0 AND EPL-1.0 AND Apache-1.1 AND Apache-2.0 AND BSD-2-Clause AND Apache-2.0 AND Apache-1.1 AND BSD-3-Clause'
   - 'EPL-2.0 AND GPL-1.0-or-later AND GPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0'
   - 'EPL-1.0 AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-only OR LGPL-2.1-only AND GPL-3.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0-or-later OR GPL-2.0-or-later'
   - 'GPL-1.0-or-later'


### PR DESCRIPTION
That's a fun one.

Blocking https://github.com/coveo-platform/coveo-cloud-base-service/pull/3171 which is required to push a CVE fix downstream to a lot of services in Coveo, a quick review would be appreciated :) 

Thanks!