### PR TITLE
chore: exclusion for pillow

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -573,6 +573,7 @@ allow-licenses:
   - 'ISC AND LicenseRef-scancode-unknown-license-reference'
   - 'JSON AND LicenseRef-scancode-unknown-license-reference'
   - 'LicenseRef-scancode-public-domain AND Unlicense AND LicenseRef-scancode-unknown-license-reference'
+  - 'LicenseRef-scancode-secret-labs-2011 AND MIT-CMU'
   - 'LGPL-2.0-or-later AND LicenseRef-scancode-unknown-license-reference'
   - 'LGPL-2.1 AND LicenseRef-scancode-unknown-license-reference'
   - 'LGPL-2.1-only AND LicenseRef-scancode-unknown-license-reference'


### PR DESCRIPTION
This [here](https://github.com/coveo-platform/ops-module/actions/runs/14841616807) check failed in my PR.

I think that particular [license](https://github.com/python-pillow/Pillow/blob/main/LICENSE) is legit for our use case of undistributed internal tooling.