### PR TITLE
Support for Dependency Review v4.7.1

### DIFF
--- a/private-distributed-v2.yml
+++ b/private-distributed-v2.yml
@@ -1,59 +1,59 @@
 # Allow list for closed-source distributed projects.
 allow-licenses:
-- 0BSD
-- 0BSD AND ISC AND MIT
-- Apache-2.0
-- Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT
-- Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT
-- Apache-2.0 AND BSD-3-Clause AND Python-2.0
-- Apache-2.0 AND MIT
-- Beerware
-- BlueOak-1.0.0
-- BSD-1-Clause
-- BSD-2-Clause
-- BSD-2-Clause AND MIT
-- BSD-2-Clause-Patent
-- BSD-2-Clause-Views
-- BSD-3-Clause
-- BSD-3-Clause AND BSD-3-Clause-Clear
-- BSD-3-Clause AND ISC AND MIT
-- BSD-3-Clause AND MIT
-- BSD-3-Clause-Attribution
-- BSD-3-Clause-Clear
-- BSL-1.0
-- CC-BY-3.0
-- CC-BY-4.0
-- CC0-1.0
-- CNRI-Python
-- curl
-- HPND
-- IBM-pibs
-- ImageMagick
-- ISC
-- JSON
-- MIT
-- MIT AND ISC
-- MIT AND Python-2.0
-- MIT AND Python-2.0.1
-- MIT-0
-- MIT-advertising
-- mpi-permissive
-- NCSA
-- ODC-By-1.0
-- PDDL-1.0
-- Plexus
-- PostgreSQL
-- PSF-2.0
-- Python-2.0
-- Python-2.0.1
-- SAX-PD
-- Unlicense
-- UPL-1.0
-- W3C
-- Wsuipa
-- WTFPL
-- X11
-- X11-distribute-modifications-variant
-- Xerox
-- Zlib
-- ZPL-2.1
+  - '0BSD'
+  - '0BSD AND ISC AND MIT'
+  - 'Apache-2.0'
+  - 'Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT'
+  - 'Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT'
+  - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0'
+  - 'Apache-2.0 AND MIT'
+  - 'Beerware'
+  - 'BlueOak-1.0.0'
+  - 'BSD-1-Clause'
+  - 'BSD-2-Clause'
+  - 'BSD-2-Clause AND MIT'
+  - 'BSD-2-Clause-Patent'
+  - 'BSD-2-Clause-Views'
+  - 'BSD-3-Clause'
+  - 'BSD-3-Clause AND BSD-3-Clause-Clear'
+  - 'BSD-3-Clause AND ISC AND MIT'
+  - 'BSD-3-Clause AND MIT'
+  - 'BSD-3-Clause-Attribution'
+  - 'BSD-3-Clause-Clear'
+  - 'BSL-1.0'
+  - 'CC-BY-3.0'
+  - 'CC-BY-4.0'
+  - 'CC0-1.0'
+  - 'CNRI-Python'
+  - 'curl'
+  - 'HPND'
+  - 'IBM-pibs'
+  - 'ImageMagick'
+  - 'ISC'
+  - 'JSON'
+  - 'MIT'
+  - 'MIT AND ISC'
+  - 'MIT AND Python-2.0'
+  - 'MIT AND Python-2.0.1'
+  - 'MIT-0'
+  - 'MIT-advertising'
+  - 'mpi-permissive'
+  - 'NCSA'
+  - 'ODC-By-1.0'
+  - 'PDDL-1.0'
+  - 'Plexus'
+  - 'PostgreSQL'
+  - 'PSF-2.0'
+  - 'Python-2.0'
+  - 'Python-2.0.1'
+  - 'SAX-PD'
+  - 'Unlicense'
+  - 'UPL-1.0'
+  - 'W3C'
+  - 'Wsuipa'
+  - 'WTFPL'
+  - 'X11'
+  - 'X11-distribute-modifications-variant'
+  - 'Xerox'
+  - 'Zlib'
+  - 'ZPL-2.1'

--- a/private-undistributed-v2.yml
+++ b/private-undistributed-v2.yml
@@ -1,277 +1,277 @@
 # Allow list for closed-source undistributed projects.
 allow-licenses:
-- 0BSD
-- 0BSD AND Apache-2.0 AND BSD-3-Clause AND MIT
-- 0BSD AND Apache-2.0 AND BSD-3-Clause AND MIT AND LicenseRef-scancode-unknown-license-reference
-- 0BSD AND BSD-2-Clause
-- 0BSD AND BSD-2-Clause AND BSD-3-Clause
-- 0BSD AND BSD-2-Clause AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference
-- 0BSD AND BSD-2-Clause AND LicenseRef-scancode-unknown-license-reference
-- 0BSD AND ISC AND MIT
-- 0BSD AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference
-- 0BSD AND LicenseRef-scancode-unknown-license-reference
-- AFL-2.1
-- AFL-2.1 AND LicenseRef-scancode-unknown-license-reference
-- AFL-3.0
-- AFL-3.0 AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0
-- Apache-2.0 AND BSD-2-Clause
-- Apache-2.0 AND BSD-2-Clause AND BlueOak-1.0.0 AND CC0-1.0 AND ISC AND MIT
-- Apache-2.0 AND BSD-2-Clause AND BlueOak-1.0.0 AND CC0-1.0 AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT
-- Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND BSD-2-Clause AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND LGPL-3.0-or-later AND LicenseRef-scancode-other-permissive AND MIT AND MPL-2.0
-- Apache-2.0 AND BSD-2-Clause AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND LGPL-3.0-or-later AND MIT
-- Apache-2.0 AND BSD-2-Clause AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND ISC AND MIT
-- Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND BSD-3-Clause AND GPL-3.0-only AND MIT
-- Apache-2.0 AND BSD-3-Clause AND GPL-3.0-only AND MIT AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1
-- Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1 AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND BSD-3-Clause AND MIT AND Zlib
-- Apache-2.0 AND BSD-3-Clause AND MIT AND Zlib AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND BSD-3-Clause AND MPL-2.0
-- Apache-2.0 AND BSD-3-Clause AND MPL-2.0 AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND BSD-3-Clause AND Python-2.0
-- Apache-2.0 AND BSD-3-Clause AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND CNRI-Python
-- Apache-2.0 AND CNRI-Python AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND EPL-1.0 AND EPL-2.0
-- Apache-2.0 AND EPL-1.0 AND EPL-2.0 AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND LGPL-3.0-or-later
-- Apache-2.0 AND LGPL-3.0-or-later AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND LGPL-3.0-or-later AND MIT
-- Apache-2.0 AND LGPL-3.0-or-later AND MIT AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND MIT AND MIT-0
-- Apache-2.0 AND MIT AND MIT-0 AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 AND MIT AND MPL-2.0
-- Apache-2.0 AND MIT AND MPL-2.0 AND LicenseRef-scancode-unknown-license-reference
-- Apache-2.0 WITH LLVM-exception
-- Apache-2.0 WITH LLVM-exception AND LicenseRef-scancode-unknown-license-reference
-- APL-1.0
-- APL-1.0 AND LicenseRef-scancode-unknown-license-reference
-- Artistic-1.0 AND Artistic-2.0
-- Artistic-1.0-Perl AND Artistic-2.0 AND GPL-1.0-or-later
-- Artistic-2.0
-- Artistic-2.0 AND GPL-2.0-or-later
-- Artistic-2.0 AND LicenseRef-scancode-unknown-license-reference
-- Beerware
-- Beerware AND LicenseRef-scancode-unknown-license-reference
-- BlueOak-1.0.0
-- BlueOak-1.0.0 AND LicenseRef-scancode-unknown-license-reference
-- BSD-1-Clause
-- BSD-1-Clause AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause
-- BSD-2-Clause AND BSD-2-Clause-Views
-- BSD-2-Clause AND BSD-2-Clause-Views AND BSD-3-Clause
-- BSD-2-Clause AND BSD-2-Clause-Views AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND BSD-2-Clause-Views AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND BSD-3-Clause
-- BSD-2-Clause AND BSD-3-Clause AND GPL-1.0-or-later
-- BSD-2-Clause AND BSD-3-Clause AND GPL-1.0-or-later AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND BSD-3-Clause AND ISC AND Python-2.0
-- BSD-2-Clause AND BSD-3-Clause AND ISC AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND BSD-3-Clause AND LGPL-2.0-or-later AND MIT
-- BSD-2-Clause AND BSD-3-Clause AND LGPL-2.0-or-later AND MIT AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND BSD-3-Clause AND LGPL-3.0-only
-- BSD-2-Clause AND BSD-3-Clause AND LGPL-3.0-only AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND BSD-3-Clause AND Python-2.0
-- BSD-2-Clause AND BSD-3-Clause AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND BSD-4-Clause
-- BSD-2-Clause AND BSD-4-Clause AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND ISC
-- BSD-2-Clause AND ISC AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND ISC AND Python-2.0
-- BSD-2-Clause AND ISC AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND LGPL-3.0-or-later AND LicenseRef-scancode-alliance-open-media-patent-1.0 AND LicenseRef-scancode-other-permissive AND MIT AND MPL-2.0
-- BSD-2-Clause AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause AND MIT
-- BSD-2-Clause AND MIT AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause-Patent
-- BSD-2-Clause-Patent AND LicenseRef-scancode-unknown-license-reference
-- BSD-2-Clause-Views
-- BSD-2-Clause-Views AND LicenseRef-scancode-unknown-license-reference
-- BSD-3-Clause
-- BSD-3-Clause AND BSD-3-Clause-Clear
-- BSD-3-Clause AND BSD-3-Clause-Clear AND LicenseRef-scancode-unknown-license-reference
-- BSD-3-Clause AND ISC AND MIT
-- BSD-3-Clause AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference
-- BSD-3-Clause AND LicenseRef-scancode-generic-cla AND MIT
-- BSD-3-Clause AND LicenseRef-scancode-protobuf
-- BSD-3-Clause AND LicenseRef-scancode-protobuf AND LicenseRef-scancode-unknown-license-reference
-- BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference
-- BSD-3-Clause-Attribution
-- BSD-3-Clause-Attribution AND LicenseRef-scancode-unknown-license-reference
-- BSD-3-Clause-Clear
-- BSD-3-Clause-Clear AND LicenseRef-scancode-unknown-license-reference
-- BSD-4-Clause
-- BSD-4-Clause AND LicenseRef-scancode-unknown-license-reference
-- BSL-1.0
-- BSL-1.0 AND LicenseRef-scancode-unknown-license-reference
-- CC-BY-3.0
-- CC-BY-3.0 AND LicenseRef-scancode-unknown-license-reference
-- CC-BY-4.0
-- CC-BY-4.0
-- CC-BY-4.0 AND CC-BY-SA-4.0 AND GPL-2.0-only AND GPL-2.0-or-later
-- CC-BY-4.0 AND CC-BY-SA-4.0 AND GPL-2.0-only AND GPL-2.0-or-later AND LicenseRef-scancode-unknown-license-reference
-- CC0-1.0
-- CC0-1.0 AND LicenseRef-scancode-unknown-license-reference
-- CDDL-1.0
-- CDDL-1.0 AND LicenseRef-scancode-unknown-license-reference
-- CDDL-1.1
-- CDDL-1.1 AND (CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0) AND GPL-2.0-only
-- CDDL-1.1 AND (CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0) AND GPL-2.0-only AND LicenseRef-scancode-unknown-license-reference
-- CDDL-1.1 AND LicenseRef-scancode-unknown-license-reference
-- CNRI-Python
-- CNRI-Python AND LicenseRef-scancode-unknown-license-reference
-- CPL-1.0
-- CPL-1.0 AND LicenseRef-scancode-unknown-license-reference
-- curl
-- curl AND LicenseRef-scancode-unknown-license-reference
-- EPL-1.0
-- EPL-1.0 AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-only
-- EPL-1.0 AND LicenseRef-scancode-unknown-license-reference
-- EPL-2.0
-- EPL-2.0 AND Apache-2.0 AND BSD-3-Clause
-- EPL-2.0 AND Apache-2.0 AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference
-- EPL-2.0 AND BSD-3-Clause AND Apache-1.1 AND EPL-2.0 AND EPL-1.0 AND Apache-1.1 AND Apache-2.0 AND BSD-2-Clause AND Apache-2.0 AND Apache-1.1 AND BSD-3-Clause
-- EPL-2.0 AND GPL-1.0-or-later AND GPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0
-- EPL-2.0 AND GPL-1.0-or-later AND GPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0 AND LicenseRef-scancode-unknown-license-reference
-- EPL-2.0 AND LicenseRef-scancode-unknown-license-reference
-- GPL-1.0-or-later
-- GPL-1.0-or-later AND LicenseRef-scancode-unknown-license-reference
-- GPL-2.0-only
-- GPL-2.0-only AND LicenseRef-scancode-unknown-license-reference
-- GPL-2.0-or-later
-- GPL-2.0-or-later AND LicenseRef-scancode-unknown-license-reference
-- GPL-3.0-only
-- GPL-3.0-only AND GPL-3.0-or-later AND LGPL-3.0-only
-- GPL-3.0-only AND GPL-3.0-or-later AND LGPL-3.0-only AND LicenseRef-scancode-unknown-license-reference
-- GPL-3.0-only AND LicenseRef-scancode-unknown-license-reference
-- GPL-3.0-or-later
-- GPL-3.0-or-later AND LGPL-2.1-only
-- GPL-3.0-or-later AND LGPL-2.1-only AND curl
-- GPL-3.0-or-later AND LGPL-2.1-only AND curl AND LicenseRef-scancode-unknown-license-reference
-- GPL-3.0-or-later AND LGPL-2.1-only AND LicenseRef-scancode-unknown-license-reference
-- GPL-3.0-or-later AND LicenseRef-scancode-unknown-license-reference
-- HPND
-- HPND AND LicenseRef-scancode-unknown-license-reference
-- IBM-pibs
-- IBM-pibs AND LicenseRef-scancode-unknown-license-reference
-- ImageMagick
-- ImageMagick AND LicenseRef-scancode-unknown-license-reference
-- ISC
-- ISC AND LicenseRef-scancode-unknown-license-reference
-- ISC AND MIT AND MPL-2.0
-- JSON
-- JSON AND LicenseRef-scancode-unknown-license-reference
-- JSON AND MIT
-- LGPL-2.0-or-later
-- LGPL-2.0-or-later AND LicenseRef-scancode-unknown-license-reference
-- LGPL-2.1
-- LGPL-2.1 AND LicenseRef-scancode-unknown-license-reference
-- LGPL-2.1+
-- LGPL-2.1+ AND LicenseRef-scancode-unknown-license-reference
-- LGPL-2.1-only
-- LGPL-2.1-only AND GPL-3.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0-or-later
-- LGPL-2.1-only AND LicenseRef-scancode-unknown-license-reference
-- LGPL-2.1-only AND MIT AND MPL-1.1
-- LGPL-2.1-only AND MIT AND MPL-1.1 AND LicenseRef-scancode-unknown-license-reference
-- LGPL-3.0
-- LGPL-3.0 AND LicenseRef-scancode-unknown-license-reference
-- LGPL-3.0-only
-- LGPL-3.0-only AND LicenseRef-scancode-unknown-license-reference
-- LGPL-3.0-or-later
-- LGPL-3.0-or-later AND LicenseRef-scancode-unknown-license-reference
-- LGPL-3.0-or-later WITH openvpn-openssl-exception
-- LGPL-3.0-or-later WITH openvpn-openssl-exception AND LicenseRef-scancode-unknown-license-reference
-- LicenseRef-scancode-dco-1.1 AND MIT
-- LicenseRef-scancode-public-domain AND Unlicense
-- LicenseRef-scancode-public-domain AND Unlicense AND LicenseRef-scancode-unknown-license-reference
-- LicenseRef-scancode-secret-labs-2011 AND MIT-CMU
-- LicenseRef-scancode-unknown-license-reference
-- MIT
-- MIT AND ISC
-- MIT AND ISC AND LicenseRef-scancode-unknown-license-reference
-- MIT AND LicenseRef-scancode-unknown-license-reference
-- MIT AND MIT-0
-- MIT AND MIT-0 AND LicenseRef-scancode-unknown-license-reference
-- MIT AND MIT-CMU
-- MIT AND MIT-CMU AND LicenseRef-scancode-unknown-license-reference
-- MIT AND MPL-2.0
-- MIT AND MPL-2.0 AND LicenseRef-scancode-unknown-license-reference
-- MIT AND OSL-3.0
-- MIT AND PSF-2.0
-- MIT AND PSF-2.0 AND LicenseRef-scancode-unknown-license-reference
-- MIT AND PSF-2.0 AND Python-2.0
-- MIT AND Python-2.0
-- MIT AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference
-- MIT AND Python-2.0.1
-- MIT AND Python-2.0.1 AND LicenseRef-scancode-unknown-license-reference
-- MIT AND ZPL-2.1
-- MIT AND ZPL-2.1 AND LicenseRef-scancode-unknown-license-reference
-- MIT-0
-- MIT-0 AND LicenseRef-scancode-unknown-license-reference
-- MIT-advertising
-- MIT-advertising AND LicenseRef-scancode-unknown-license-reference
-- mpi-permissive
-- mpi-permissive AND LicenseRef-scancode-unknown-license-reference
-- MPL-1.1
-- MPL-1.1 AND LicenseRef-scancode-unknown-license-reference
-- MPL-2.0
-- MPL-2.0 AND LicenseRef-scancode-unknown-license-reference
-- NCSA
-- NCSA AND LicenseRef-scancode-unknown-license-reference
-- Nokia
-- Nokia AND LicenseRef-scancode-unknown-license-reference
-- ODC-By-1.0
-- ODC-By-1.0 AND LicenseRef-scancode-unknown-license-reference
-- OFL-1.1
-- OFL-1.1 AND LicenseRef-scancode-unknown-license-reference
-- PDDL-1.0
-- PDDL-1.0 AND LicenseRef-scancode-unknown-license-reference
-- Plexus
-- Plexus AND LicenseRef-scancode-unknown-license-reference
-- PostgreSQL
-- PostgreSQL AND LicenseRef-scancode-unknown-license-reference
-- PSF-2.0
-- PSF-2.0 AND LicenseRef-scancode-unknown-license-reference
-- Python-2.0
-- Python-2.0 AND LicenseRef-scancode-unknown-license-reference
-- Python-2.0 AND Python-2.0 AND BSD-3-Clause AND Python-2.0 AND BSD-3-Clause AND 0BSD
-- Python-2.0 AND Python-2.0 AND BSD-3-Clause AND Python-2.0 AND BSD-3-Clause AND 0BSD AND LicenseRef-scancode-unknown-license-reference
-- Python-2.0.1
-- Python-2.0.1 AND LicenseRef-scancode-unknown-license-reference
-- Ruby
-- Ruby AND LicenseRef-scancode-unknown-license-reference
-- SAX-PD
-- SAX-PD AND LicenseRef-scancode-unknown-license-reference
-- SPL-1.0
-- SPL-1.0 AND LicenseRef-scancode-unknown-license-reference
-- Unlicense
-- Unlicense AND LicenseRef-scancode-unknown-license-reference
-- UPL-1.0
-- UPL-1.0 AND LicenseRef-scancode-unknown-license-reference
-- W3C
-- W3C AND LicenseRef-scancode-unknown-license-reference
-- Wsuipa
-- Wsuipa AND LicenseRef-scancode-unknown-license-reference
-- WTFPL
-- WTFPL AND LicenseRef-scancode-unknown-license-reference
-- X11
-- X11 AND LicenseRef-scancode-unknown-license-reference
-- X11-distribute-modifications-variant
-- X11-distribute-modifications-variant AND LicenseRef-scancode-unknown-license-reference
-- Xerox
-- Xerox AND LicenseRef-scancode-unknown-license-reference
-- xpp
-- xpp AND LicenseRef-scancode-unknown-license-reference
-- YPL-1.1
-- YPL-1.1 AND LicenseRef-scancode-unknown-license-reference
-- Zlib
-- Zlib AND LicenseRef-scancode-unknown-license-reference
-- ZPL-2.1
-- ZPL-2.1 AND LicenseRef-scancode-unknown-license-reference
+  - '0BSD'
+  - '0BSD AND Apache-2.0 AND BSD-3-Clause AND MIT'
+  - '0BSD AND Apache-2.0 AND BSD-3-Clause AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - '0BSD AND BSD-2-Clause'
+  - '0BSD AND BSD-2-Clause AND BSD-3-Clause'
+  - '0BSD AND BSD-2-Clause AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - '0BSD AND BSD-2-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - '0BSD AND ISC AND MIT'
+  - '0BSD AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - '0BSD AND LicenseRef-scancode-unknown-license-reference'
+  - 'AFL-2.1'
+  - 'AFL-2.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'AFL-3.0'
+  - 'AFL-3.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0'
+  - 'Apache-2.0 AND BSD-2-Clause'
+  - 'Apache-2.0 AND BSD-2-Clause AND BlueOak-1.0.0 AND CC0-1.0 AND ISC AND MIT'
+  - 'Apache-2.0 AND BSD-2-Clause AND BlueOak-1.0.0 AND CC0-1.0 AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT'
+  - 'Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND BSD-2-Clause AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND LGPL-3.0-or-later AND LicenseRef-scancode-other-permissive AND MIT AND MPL-2.0'
+  - 'Apache-2.0 AND BSD-2-Clause AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND LGPL-3.0-or-later AND MIT'
+  - 'Apache-2.0 AND BSD-2-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND ISC AND MIT'
+  - 'Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND BSD-3-Clause AND GPL-3.0-only AND MIT'
+  - 'Apache-2.0 AND BSD-3-Clause AND GPL-3.0-only AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1'
+  - 'Apache-2.0 AND BSD-3-Clause AND MIT AND OFL-1.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND BSD-3-Clause AND MIT AND Zlib'
+  - 'Apache-2.0 AND BSD-3-Clause AND MIT AND Zlib AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND BSD-3-Clause AND MPL-2.0'
+  - 'Apache-2.0 AND BSD-3-Clause AND MPL-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0'
+  - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND CNRI-Python'
+  - 'Apache-2.0 AND CNRI-Python AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND EPL-1.0 AND EPL-2.0'
+  - 'Apache-2.0 AND EPL-1.0 AND EPL-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND LGPL-3.0-or-later'
+  - 'Apache-2.0 AND LGPL-3.0-or-later AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND LGPL-3.0-or-later AND MIT'
+  - 'Apache-2.0 AND LGPL-3.0-or-later AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND MIT AND MIT-0'
+  - 'Apache-2.0 AND MIT AND MIT-0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 AND MIT AND MPL-2.0'
+  - 'Apache-2.0 AND MIT AND MPL-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Apache-2.0 WITH LLVM-exception'
+  - 'Apache-2.0 WITH LLVM-exception AND LicenseRef-scancode-unknown-license-reference'
+  - 'APL-1.0'
+  - 'APL-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Artistic-1.0 AND Artistic-2.0'
+  - 'Artistic-1.0-Perl AND Artistic-2.0 AND GPL-1.0-or-later'
+  - 'Artistic-2.0'
+  - 'Artistic-2.0 AND GPL-2.0-or-later'
+  - 'Artistic-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Beerware'
+  - 'Beerware AND LicenseRef-scancode-unknown-license-reference'
+  - 'BlueOak-1.0.0'
+  - 'BlueOak-1.0.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-1-Clause'
+  - 'BSD-1-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause'
+  - 'BSD-2-Clause AND BSD-2-Clause-Views'
+  - 'BSD-2-Clause AND BSD-2-Clause-Views AND BSD-3-Clause'
+  - 'BSD-2-Clause AND BSD-2-Clause-Views AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND BSD-2-Clause-Views AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND BSD-3-Clause'
+  - 'BSD-2-Clause AND BSD-3-Clause AND GPL-1.0-or-later'
+  - 'BSD-2-Clause AND BSD-3-Clause AND GPL-1.0-or-later AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND BSD-3-Clause AND ISC AND Python-2.0'
+  - 'BSD-2-Clause AND BSD-3-Clause AND ISC AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND BSD-3-Clause AND LGPL-2.0-or-later AND MIT'
+  - 'BSD-2-Clause AND BSD-3-Clause AND LGPL-2.0-or-later AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND BSD-3-Clause AND LGPL-3.0-only'
+  - 'BSD-2-Clause AND BSD-3-Clause AND LGPL-3.0-only AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND BSD-3-Clause AND Python-2.0'
+  - 'BSD-2-Clause AND BSD-3-Clause AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND BSD-4-Clause'
+  - 'BSD-2-Clause AND BSD-4-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND ISC'
+  - 'BSD-2-Clause AND ISC AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND ISC AND Python-2.0'
+  - 'BSD-2-Clause AND ISC AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND LGPL-3.0-or-later AND LicenseRef-scancode-alliance-open-media-patent-1.0 AND LicenseRef-scancode-other-permissive AND MIT AND MPL-2.0'
+  - 'BSD-2-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause AND MIT'
+  - 'BSD-2-Clause AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause-Patent'
+  - 'BSD-2-Clause-Patent AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-2-Clause-Views'
+  - 'BSD-2-Clause-Views AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-3-Clause'
+  - 'BSD-3-Clause AND BSD-3-Clause-Clear'
+  - 'BSD-3-Clause AND BSD-3-Clause-Clear AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-3-Clause AND ISC AND MIT'
+  - 'BSD-3-Clause AND ISC AND MIT AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-3-Clause AND LicenseRef-scancode-generic-cla AND MIT'
+  - 'BSD-3-Clause AND LicenseRef-scancode-protobuf'
+  - 'BSD-3-Clause AND LicenseRef-scancode-protobuf AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-3-Clause-Attribution'
+  - 'BSD-3-Clause-Attribution AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-3-Clause-Clear'
+  - 'BSD-3-Clause-Clear AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSD-4-Clause'
+  - 'BSD-4-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - 'BSL-1.0'
+  - 'BSL-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'CC-BY-3.0'
+  - 'CC-BY-3.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'CC-BY-4.0'
+  - 'CC-BY-4.0'
+  - 'CC-BY-4.0 AND CC-BY-SA-4.0 AND GPL-2.0-only AND GPL-2.0-or-later'
+  - 'CC-BY-4.0 AND CC-BY-SA-4.0 AND GPL-2.0-only AND GPL-2.0-or-later AND LicenseRef-scancode-unknown-license-reference'
+  - 'CC0-1.0'
+  - 'CC0-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'CDDL-1.0'
+  - 'CDDL-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'CDDL-1.1'
+  - 'CDDL-1.1 AND (CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0) AND GPL-2.0-only'
+  - 'CDDL-1.1 AND (CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0) AND GPL-2.0-only AND LicenseRef-scancode-unknown-license-reference'
+  - 'CDDL-1.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'CNRI-Python'
+  - 'CNRI-Python AND LicenseRef-scancode-unknown-license-reference'
+  - 'CPL-1.0'
+  - 'CPL-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'curl'
+  - 'curl AND LicenseRef-scancode-unknown-license-reference'
+  - 'EPL-1.0'
+  - 'EPL-1.0 AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-only'
+  - 'EPL-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'EPL-2.0'
+  - 'EPL-2.0 AND Apache-2.0 AND BSD-3-Clause'
+  - 'EPL-2.0 AND Apache-2.0 AND BSD-3-Clause AND LicenseRef-scancode-unknown-license-reference'
+  - 'EPL-2.0 AND BSD-3-Clause AND Apache-1.1 AND EPL-2.0 AND EPL-1.0 AND Apache-1.1 AND Apache-2.0 AND BSD-2-Clause AND Apache-2.0 AND Apache-1.1 AND BSD-3-Clause'
+  - 'EPL-2.0 AND GPL-1.0-or-later AND GPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0'
+  - 'EPL-2.0 AND GPL-1.0-or-later AND GPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'EPL-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'GPL-1.0-or-later'
+  - 'GPL-1.0-or-later AND LicenseRef-scancode-unknown-license-reference'
+  - 'GPL-2.0-only'
+  - 'GPL-2.0-only AND LicenseRef-scancode-unknown-license-reference'
+  - 'GPL-2.0-or-later'
+  - 'GPL-2.0-or-later AND LicenseRef-scancode-unknown-license-reference'
+  - 'GPL-3.0-only'
+  - 'GPL-3.0-only AND GPL-3.0-or-later AND LGPL-3.0-only'
+  - 'GPL-3.0-only AND GPL-3.0-or-later AND LGPL-3.0-only AND LicenseRef-scancode-unknown-license-reference'
+  - 'GPL-3.0-only AND LicenseRef-scancode-unknown-license-reference'
+  - 'GPL-3.0-or-later'
+  - 'GPL-3.0-or-later AND LGPL-2.1-only'
+  - 'GPL-3.0-or-later AND LGPL-2.1-only AND curl'
+  - 'GPL-3.0-or-later AND LGPL-2.1-only AND curl AND LicenseRef-scancode-unknown-license-reference'
+  - 'GPL-3.0-or-later AND LGPL-2.1-only AND LicenseRef-scancode-unknown-license-reference'
+  - 'GPL-3.0-or-later AND LicenseRef-scancode-unknown-license-reference'
+  - 'HPND'
+  - 'HPND AND LicenseRef-scancode-unknown-license-reference'
+  - 'IBM-pibs'
+  - 'IBM-pibs AND LicenseRef-scancode-unknown-license-reference'
+  - 'ImageMagick'
+  - 'ImageMagick AND LicenseRef-scancode-unknown-license-reference'
+  - 'ISC'
+  - 'ISC AND LicenseRef-scancode-unknown-license-reference'
+  - 'ISC AND MIT AND MPL-2.0'
+  - 'JSON'
+  - 'JSON AND LicenseRef-scancode-unknown-license-reference'
+  - 'JSON AND MIT'
+  - 'LGPL-2.0-or-later'
+  - 'LGPL-2.0-or-later AND LicenseRef-scancode-unknown-license-reference'
+  - 'LGPL-2.1'
+  - 'LGPL-2.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'LGPL-2.1+'
+  - 'LGPL-2.1+ AND LicenseRef-scancode-unknown-license-reference'
+  - 'LGPL-2.1-only'
+  - 'LGPL-2.1-only AND GPL-3.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-3.0-or-later'
+  - 'LGPL-2.1-only AND LicenseRef-scancode-unknown-license-reference'
+  - 'LGPL-2.1-only AND MIT AND MPL-1.1'
+  - 'LGPL-2.1-only AND MIT AND MPL-1.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'LGPL-3.0'
+  - 'LGPL-3.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'LGPL-3.0-only'
+  - 'LGPL-3.0-only AND LicenseRef-scancode-unknown-license-reference'
+  - 'LGPL-3.0-or-later'
+  - 'LGPL-3.0-or-later AND LicenseRef-scancode-unknown-license-reference'
+  - 'LGPL-3.0-or-later WITH openvpn-openssl-exception'
+  - 'LGPL-3.0-or-later WITH openvpn-openssl-exception AND LicenseRef-scancode-unknown-license-reference'
+  - 'LicenseRef-scancode-dco-1.1 AND MIT'
+  - 'LicenseRef-scancode-public-domain AND Unlicense'
+  - 'LicenseRef-scancode-public-domain AND Unlicense AND LicenseRef-scancode-unknown-license-reference'
+  - 'LicenseRef-scancode-secret-labs-2011 AND MIT-CMU'
+  - 'LicenseRef-scancode-unknown-license-reference'
+  - 'MIT'
+  - 'MIT AND ISC'
+  - 'MIT AND ISC AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT AND MIT-0'
+  - 'MIT AND MIT-0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT AND MIT-CMU'
+  - 'MIT AND MIT-CMU AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT AND MPL-2.0'
+  - 'MIT AND MPL-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT AND OSL-3.0'
+  - 'MIT AND PSF-2.0'
+  - 'MIT AND PSF-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT AND PSF-2.0 AND Python-2.0'
+  - 'MIT AND Python-2.0'
+  - 'MIT AND Python-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT AND Python-2.0.1'
+  - 'MIT AND Python-2.0.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT AND ZPL-2.1'
+  - 'MIT AND ZPL-2.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT-0'
+  - 'MIT-0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'MIT-advertising'
+  - 'MIT-advertising AND LicenseRef-scancode-unknown-license-reference'
+  - 'mpi-permissive'
+  - 'mpi-permissive AND LicenseRef-scancode-unknown-license-reference'
+  - 'MPL-1.1'
+  - 'MPL-1.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'MPL-2.0'
+  - 'MPL-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'NCSA'
+  - 'NCSA AND LicenseRef-scancode-unknown-license-reference'
+  - 'Nokia'
+  - 'Nokia AND LicenseRef-scancode-unknown-license-reference'
+  - 'ODC-By-1.0'
+  - 'ODC-By-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'OFL-1.1'
+  - 'OFL-1.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'PDDL-1.0'
+  - 'PDDL-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Plexus'
+  - 'Plexus AND LicenseRef-scancode-unknown-license-reference'
+  - 'PostgreSQL'
+  - 'PostgreSQL AND LicenseRef-scancode-unknown-license-reference'
+  - 'PSF-2.0'
+  - 'PSF-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Python-2.0'
+  - 'Python-2.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Python-2.0 AND Python-2.0 AND BSD-3-Clause AND Python-2.0 AND BSD-3-Clause AND 0BSD'
+  - 'Python-2.0 AND Python-2.0 AND BSD-3-Clause AND Python-2.0 AND BSD-3-Clause AND 0BSD AND LicenseRef-scancode-unknown-license-reference'
+  - 'Python-2.0.1'
+  - 'Python-2.0.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Ruby'
+  - 'Ruby AND LicenseRef-scancode-unknown-license-reference'
+  - 'SAX-PD'
+  - 'SAX-PD AND LicenseRef-scancode-unknown-license-reference'
+  - 'SPL-1.0'
+  - 'SPL-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Unlicense'
+  - 'Unlicense AND LicenseRef-scancode-unknown-license-reference'
+  - 'UPL-1.0'
+  - 'UPL-1.0 AND LicenseRef-scancode-unknown-license-reference'
+  - 'W3C'
+  - 'W3C AND LicenseRef-scancode-unknown-license-reference'
+  - 'Wsuipa'
+  - 'Wsuipa AND LicenseRef-scancode-unknown-license-reference'
+  - 'WTFPL'
+  - 'WTFPL AND LicenseRef-scancode-unknown-license-reference'
+  - 'X11'
+  - 'X11 AND LicenseRef-scancode-unknown-license-reference'
+  - 'X11-distribute-modifications-variant'
+  - 'X11-distribute-modifications-variant AND LicenseRef-scancode-unknown-license-reference'
+  - 'Xerox'
+  - 'Xerox AND LicenseRef-scancode-unknown-license-reference'
+  - 'xpp'
+  - 'xpp AND LicenseRef-scancode-unknown-license-reference'
+  - 'YPL-1.1'
+  - 'YPL-1.1 AND LicenseRef-scancode-unknown-license-reference'
+  - 'Zlib'
+  - 'Zlib AND LicenseRef-scancode-unknown-license-reference'
+  - 'ZPL-2.1'
+  - 'ZPL-2.1 AND LicenseRef-scancode-unknown-license-reference'

--- a/public-v2.yml
+++ b/public-v2.yml
@@ -1,59 +1,59 @@
 # Allow list for open-source projects.
 allow-licenses:
-- 0BSD
-- 0BSD AND ISC AND MIT
-- Apache-2.0
-- Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT
-- Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT
-- Apache-2.0 AND BSD-3-Clause AND Python-2.0
-- Apache-2.0 AND MIT
-- Apache-2.0 AND MIT
-- Apache-2.0 AND MIT AND MIT-0
-- Beerware
-- BlueOak-1.0.0
-- BSD-1-Clause
-- BSD-1-Clause AND BSD-2-Clause
-- BSD-2-Clause
-- BSD-2-Clause AND MIT
-- BSD-2-Clause-Patent
-- BSD-2-Clause-Views
-- BSD-3-Clause
-- BSD-3-Clause AND ISC AND MIT
-- BSD-3-Clause-Attribution
-- BSD-3-Clause-Clear
-- BSL-1.0
-- CC-BY-3.0
-- CC-BY-4.0
-- CC0-1.0
-- CNRI-Python
-- curl
-- HPND
-- IBM-pibs
-- ImageMagick
-- ISC
-- JSON
-- MIT
-- MIT AND ISC
-- MIT AND Python-2.0
-- MIT-0
-- MIT-advertising
-- mpi-permissive
-- NCSA
-- ODC-By-1.0
-- PDDL-1.0
-- Plexus
-- PostgreSQL
-- PSF-2.0
-- Python-2.0
-- Python-2.0.1
-- SAX-PD
-- Unlicense
-- UPL-1.0
-- W3C
-- Wsuipa
-- WTFPL
-- X11
-- X11-distribute-modifications-variant
-- Xerox
-- Zlib
-- ZPL-2.1
+  - '0BSD'
+  - '0BSD AND ISC AND MIT'
+  - 'Apache-2.0'
+  - 'Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND MIT'
+  - 'Apache-2.0 AND BSD-2-Clause AND CC0-1.0 AND ISC AND MIT'
+  - 'Apache-2.0 AND BSD-3-Clause AND Python-2.0'
+  - 'Apache-2.0 AND MIT'
+  - 'Apache-2.0 AND MIT'
+  - 'Apache-2.0 AND MIT AND MIT-0'
+  - 'Beerware'
+  - 'BlueOak-1.0.0'
+  - 'BSD-1-Clause'
+  - 'BSD-1-Clause AND BSD-2-Clause'
+  - 'BSD-2-Clause'
+  - 'BSD-2-Clause AND MIT'
+  - 'BSD-2-Clause-Patent'
+  - 'BSD-2-Clause-Views'
+  - 'BSD-3-Clause'
+  - 'BSD-3-Clause AND ISC AND MIT'
+  - 'BSD-3-Clause-Attribution'
+  - 'BSD-3-Clause-Clear'
+  - 'BSL-1.0'
+  - 'CC-BY-3.0'
+  - 'CC-BY-4.0'
+  - 'CC0-1.0'
+  - 'CNRI-Python'
+  - 'curl'
+  - 'HPND'
+  - 'IBM-pibs'
+  - 'ImageMagick'
+  - 'ISC'
+  - 'JSON'
+  - 'MIT'
+  - 'MIT AND ISC'
+  - 'MIT AND Python-2.0'
+  - 'MIT-0'
+  - 'MIT-advertising'
+  - 'mpi-permissive'
+  - 'NCSA'
+  - 'ODC-By-1.0'
+  - 'PDDL-1.0'
+  - 'Plexus'
+  - 'PostgreSQL'
+  - 'PSF-2.0'
+  - 'Python-2.0'
+  - 'Python-2.0.1'
+  - 'SAX-PD'
+  - 'Unlicense'
+  - 'UPL-1.0'
+  - 'W3C'
+  - 'Wsuipa'
+  - 'WTFPL'
+  - 'X11'
+  - 'X11-distribute-modifications-variant'
+  - 'Xerox'
+  - 'Zlib'
+  - 'ZPL-2.1'

--- a/sort.py
+++ b/sort.py
@@ -1,20 +1,26 @@
 import os
-import yaml
+
+from ruamel.yaml import YAML
+
 
 def sort_allow_licenses_in_file(filepath):
-    with open(filepath, 'r') as f:
-        data = yaml.safe_load(f)
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    with open(filepath, "r") as f:
+        data = yaml.load(f)
 
-    if 'allow-licenses' in data and isinstance(data['allow-licenses'], list):
-        data['allow-licenses'] = sorted(data['allow-licenses'], key=str.lower)
+    if "allow-licenses" in data and isinstance(data["allow-licenses"], list):
+        data["allow-licenses"] = sorted(data["allow-licenses"], key=str.lower)
 
-        with open(filepath, 'w') as f:
-            yaml.dump(data, f, sort_keys=False, width=1000)
+        with open(filepath, "w") as f:
+            yaml.dump(data, f)
+
 
 def main():
-    for filename in os.listdir('.'):
-        if filename.endswith('-v2.yml'):
+    for filename in os.listdir("."):
+        if filename.endswith("-v2.yml"):
             sort_allow_licenses_in_file(filename)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request introduces several changes to license allow-lists across multiple YAML configuration files (`private-distributed-v2.yml`, `private-undistributed-v2.yml`, `public-v2.yml`) and adds a Python script (`sort.py`) to automate sorting of license entries. The key updates include adding new composite licenses to the allow-lists and implementing functionality for maintaining sorted entries.

### Updates to license allow-lists:

* **`private-distributed-v2.yml`:** Added multiple composite licenses to the allow-list to support projects with complex licensing requirements. [[1]](diffhunk://#diff-56e086436f9ac99c5251b49b031ad974792468603a24186e3adae12d28b6a544R4-R20) [[2]](diffhunk://#diff-56e086436f9ac99c5251b49b031ad974792468603a24186e3adae12d28b6a544R35-R37)
* **`private-undistributed-v2.yml`:** Expanded the allow-list with numerous composite licenses, including entries with unknown license references for undistributed projects.
* **`public-v2.yml`:** Updated the allow-list for open-source projects with new composite licenses and added support for licenses combining MIT, ISC, and Python-related terms. [[1]](diffhunk://#diff-f2f3f1b51cfb9440b8d75f298b93950f5598ef8873e6f0434b04681618599c82R4-R21) [[2]](diffhunk://#diff-f2f3f1b51cfb9440b8d75f298b93950f5598ef8873e6f0434b04681618599c82R36-R37)

### Automation for license entry management:

* **`sort.py`:** Introduced a Python script to automatically sort the `allow-licenses` entries in YAML files. This ensures consistency and readability across all configuration files.