### PR TITLE
feat: add missing licence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
 # They will automatically be added as reviewers.
-* @coveo/r-d-security-defence @coveo/legal-team @JPLachance @tbronsonCoveo
+* @coveo-platform/r-d-defense @coveo/legal-team

--- a/private-undistributed-v2.yml
+++ b/private-undistributed-v2.yml
@@ -405,6 +405,7 @@ allow-licenses:
   - 'LGPL-3.0-or-later'
   - 'LGPL-3.0-or-later WITH openvpn-openssl-exception'
   - 'LicenseRef-scancode-other-permissive'
+  - 'LicenseRef-scancode-protobuf'
   - 'LicenseRef-scancode-unknown-license-reference'
   - 'MIT'
   - 'MIT-0'


### PR DESCRIPTION
https://coveord.atlassian.net/browse/DEF-2843

The licence already exists in `private-undistributed.yml`, make it available to `dependency-review-action-v3`.

For https://coveord.atlassian.net/browse/PES-587