### PR TITLE
Add whitelist for "nan" NPM package

### DIFF
--- a/private-undistributed-v2.yml
+++ b/private-undistributed-v2.yml
@@ -404,7 +404,7 @@ allow-licenses:
   - 'LGPL-3.0-only'
   - 'LGPL-3.0-or-later'
   - 'LGPL-3.0-or-later WITH openvpn-openssl-exception'
-  - 'LicenseRef-scancode-dco-1.1 AND MIT'
+  - 'LicenseRef-scancode-dco-1.1'
   - 'LicenseRef-scancode-other-permissive'
   - 'LicenseRef-scancode-protobuf'
   - 'LicenseRef-scancode-secret-labs-2011'

--- a/private-undistributed-v2.yml
+++ b/private-undistributed-v2.yml
@@ -404,6 +404,7 @@ allow-licenses:
   - 'LGPL-3.0-only'
   - 'LGPL-3.0-or-later'
   - 'LGPL-3.0-or-later WITH openvpn-openssl-exception'
+  - 'LicenseRef-scancode-dco-1.1 AND MIT'
   - 'LicenseRef-scancode-other-permissive'
   - 'LicenseRef-scancode-protobuf'
   - 'LicenseRef-scancode-secret-labs-2011'

--- a/public-v2.yml
+++ b/public-v2.yml
@@ -22,6 +22,7 @@ allow-licenses:
   - 'ImageMagick'
   - 'ISC'
   - 'JSON'
+  - 'LicenseRef-scancode-dco-1.1 AND MIT'
   - 'MIT'
   - 'MIT-0'
   - 'MIT-advertising'

--- a/public-v2.yml
+++ b/public-v2.yml
@@ -22,7 +22,6 @@ allow-licenses:
   - 'ImageMagick'
   - 'ISC'
   - 'JSON'
-  - 'LicenseRef-scancode-dco-1.1 AND MIT'
   - 'MIT'
   - 'MIT-0'
   - 'MIT-advertising'


### PR DESCRIPTION
I have a PR blocked because of a transitive dependency to [nan](https://www.npmjs.com/package/nan) : https://github.com/coveo-platform/boulangerie/actions/runs/15827635678?pr=112

Somehow the license is extracted as `LicenseRef-scancode-dco-1.1 AND MIT`.

https://coveord.atlassian.net/browse/NODEC-55