### PR TITLE
fix(license): Add jdom2 to allow list [UA-5791]

### DIFF
--- a/private-undistributed-v2.yml
+++ b/private-undistributed-v2.yml
@@ -7,6 +7,9 @@ allow-dependencies-licenses:
   - 'pkg:maven/com.google.errorprone/error_prone_annotations'
   # org.aspectj/aspectjweaver has an EPL-2.0 license but it is not detected properly (https://github.com/eclipse-aspectj/aspectj/blob/master/aspectjweaver/pom.xml#L21-L27 / https://github.com/eclipse-aspectj/aspectj?tab=License-1-ov-file)
   - 'pkg:maven/org.aspectj/aspectjweaver'
+  # org.jdom/jdom2 has a custom license that is classified as OTHER by ClearlyDefined (https://github.com/hunterhacker/jdom/blob/master/LICENSE.txt)
+  # mvnrepository summarizes it as "Similar to Apache License but with the acknowledgment clause removed" (https://mvnrepository.com/artifact/org.jdom/jdom2/2.0.6.1)
+  - 'pkg:maven/org.jdom/jdom2'
   # org.json/json has a public domain license but it is not detected properly by GitHub (https://github.com/stleary/JSON-java/blob/master/LICENSE)
   - 'pkg:maven/org.json/json'
   # All Spring Framework, Spring Boot, Spring Cloud and Spring Data.


### PR DESCRIPTION
A recent dependency update PR was blocking on transitive dependency jdom2 version `2.0.6.1` (coming from `2.0.6`). These versions have the same license to my knowledge.

This PR is to add `org.jdom/jdom2` ([jdom.org](http://www.jdom.org/), [GitHub](https://github.com/hunterhacker/jdom/), [mvnrepository](https://mvnrepository.com/artifact/org.jdom/jdom2/2.0.6.1)) to the allow list.