### PR TITLE
Fix license issue with Jersey-Common

### DIFF
--- a/private-undistributed-v2.yml
+++ b/private-undistributed-v2.yml
@@ -7,6 +7,8 @@ allow-dependencies-licenses:
   - 'pkg:maven/com.google.errorprone/error_prone_annotations'
   # org.aspectj/aspectjweaver has an EPL-2.0 license but it is not detected properly (https://github.com/eclipse-aspectj/aspectj/blob/master/aspectjweaver/pom.xml#L21-L27 / https://github.com/eclipse-aspectj/aspectj?tab=License-1-ov-file)
   - 'pkg:maven/org.aspectj/aspectjweaver'
+  # org.glassfish.jersey.core/jersey-common has an EPL-2.0 license (https://github.com/eclipse-ee4j/jersey/tree/2.x?tab=License-1-ov-file#readme) but it is not being detected properly and leads to an Invalid SPDX License error.
+  - 'pkg:maven/org.glassfish.jersey.core/jersey-common'
   # org.json/json has a public domain license but it is not detected properly by GitHub (https://github.com/stleary/JSON-java/blob/master/LICENSE)
   - 'pkg:maven/org.json/json'
   # All Spring Framework, Spring Boot, Spring Cloud and Spring Data.


### PR DESCRIPTION
* Add exception for jersey common because of an invalid license

Context: https://github.com/coveo-platform/usageanalytics/pull/3240