### PR TITLE
fix(FINOPS-2210): Qhull license

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -434,6 +434,7 @@ allow-licenses:
   - 'PSF-2.0'
   - 'Python-2.0'
   - 'Python-2.0.1'
+  - 'Qhull'
   - 'Ruby'
   - 'SAX-PD'
   - 'SPL-1.0'


### PR DESCRIPTION
- Spicy 1.16 uses this license:

  https://github.com/scipy/scipy/blob/main/LICENSES_bundled.txt#L84

- Qhull license details: 

  https://github.com/bjnortier/qhull/blob/master/LICENSE

- Dependency review run: 

  https://github.com/coveo-platform/cloud-costs/actions/runs/16477597225