### PR TITLE
Adding 'CC-BY-SA-4.0' license to private-undistributed.yml

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -384,6 +384,7 @@ allow-licenses:
   - 'BSL-1.0'
   - 'CC-BY-3.0'
   - 'CC-BY-4.0'
+  - 'CC-BY-SA-4.0'
   - 'CC0-1.0'
   - 'CDDL-1.0'
   - 'CDDL-1.1'


### PR DESCRIPTION
https://github.com/coveo-platform/security-cache-metrics-service/pull/802#issuecomment-3218758379

`CC-BY-4.0 AND CC-BY-SA-4.0 AND GPL-2.0-only` is needed and only `CC-BY-SA-4.0` is missing