### PR TITLE
Add CAL-1.0 license to private-undistributed.yml

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -383,6 +383,7 @@ allow-licenses:
   - 'BSD-3-Clause-No-Nuclear-Warranty'
   - 'BSD-4-Clause'
   - 'BSL-1.0'
+  - 'CAL-1.0'
   - 'CC-BY-3.0'
   - 'CC-BY-4.0'
   - 'CC-BY-SA-4.0'


### PR DESCRIPTION
From my quick research, the open-sourcing requirements of this license only kick in when distributing. So this license should be safe for internal undistributed projects.

This is in relation to the following PR https://github.com/coveo-platform/sre-automation/pull/159 for `logassert`