### PR TITLE
fix: Added bind-api

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -5,6 +5,8 @@
 allow-dependencies-licenses:
   # com.google.errorprone/error_prone_annotations has a Apache-2.0 license but it is not detected properly (https://github.com/google/error-prone?tab=Apache-2.0-1-ov-file#readme)
   - 'pkg:maven/com.google.errorprone/error_prone_annotations'
+  # This package is being detected has having a export compliance reference(https://github.com/jakartaee/jaxb-api/blob/554863385ac5f39e67cfd9e7bc9afc0272313b54/NOTICE.md?plain=1#L40-L47)
+  - 'pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api'
   # org.aspectj/aspectjweaver has an EPL-2.0 license but it is not detected properly (https://github.com/eclipse-aspectj/aspectj/blob/master/aspectjweaver/pom.xml#L21-L27 / https://github.com/eclipse-aspectj/aspectj?tab=License-1-ov-file)
   - 'pkg:maven/org.aspectj/aspectjweaver'
   # org.glassfish.jersey.core/jersey-common has an EPL-2.0 license (https://github.com/eclipse-ee4j/jersey/tree/2.x?tab=License-1-ov-file#readme) but it is not being detected properly and leads to an Invalid SPDX License error.


### PR DESCRIPTION
This package is being detected has having a `LicenseRef-scancode-generic-export-compliance` because of [this reference](https://github.com/jakartaee/jaxb-api/blob/554863385ac5f39e67cfd9e7bc9afc0272313b54/NOTICE.md?plain=1#L40-L47).

For now, we'll specifically add the package as allowed as Legal team is not confortable with adding a broad exclusion for this type of reference.

[Initial PR with the dependency flagged](https://github.com/coveo-platform/identity-service/pull/149)