### PR TITLE
Fix typo in license list for MITNFA

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -427,7 +427,7 @@ allow-licenses:
   - 'MIT-CMU'
   - 'MIT-0'
   - 'MIT-advertising'
-  - 'MITNFA
+  - 'MITNFA'
   - 'mpi-permissive'
   - 'MPL-1.1'
   - 'MPL-2.0'


### PR DESCRIPTION
It's probably causing all dependency review to fail
<img width="793" height="565" alt="Screenshot 2025-09-24 at 10 50 37 PM" src="https://github.com/user-attachments/assets/25ebaf9d-28c7-47c9-a527-7752f29f59ca" />
