### PR TITLE
chore: update codeowners to fix file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # the repo. Unless a later match takes precedence
 # They will automatically be added as reviewers.
 
-* @coveo-platform/r-d-defense
+* @coveo/r-d-security-defence
 
 # License specific files
 public.yml @coveo/legal-team


### PR DESCRIPTION
Previously `@coveo-platform/r-d-defense` was assigned to all files, but this team doesn't exists in the `coveo` org. I switched it to `@coveo/r-d-security-defence` to fix the CODEOWNERS file