### PR TITLE
COMAI-4671: add matplotlib exception

### DIFF
--- a/private-undistributed.yml
+++ b/private-undistributed.yml
@@ -361,6 +361,7 @@ allow-dependencies-licenses:
   # This is public domain https://github.com/xmlpull-xpp3/xmlpull-xpp3/blob/master/pom.xml#L18-L24
   - 'pkg:maven/xmlpull/xmlpull'
   - 'pkg:pypi/torchmetrics'
+  - 'pkg:pypi/matplotlib' # false positive detected as CAL-1, see https://coveord.atlassian.net/browse/COMAI-4671
 
 # Allow list for closed-source undistributed projects.
 allow-licenses:


### PR DESCRIPTION
## Context
https://coveord.atlassian.net/browse/COMAI-4671
https://coveo.slack.com/archives/CFNCWR214/p1759525008567539
https://coveord.atlassian.net/browse/PES-1312

Matplotlib regularly detected as a false positive on dependabot license check

## Solution
Adding it as suggested in the slack thread to the list of exception